### PR TITLE
Cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About billiard
 
 Home: http://github.com/celery/billiard
 
-Package license: BSD License
+Package license: BSD 3-Clause
 
 Feedstock license: BSD 3-Clause
 

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install --single-version-externally-managed --record=record.txt
-if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,38 +1,38 @@
 {% set version = "3.3.0.23" %}
 
 package:
-    name: billiard
-    version: {{ version }}
+  name: billiard
+  version: {{ version }}
 
 source:
-    fn: billiard-{{ version }}.tar.gz
-    url: https://pypi.python.org/packages/source/b/billiard/billiard-{{ version }}.tar.gz
-    md5: 6ee416e1e7c8d8164ce29d7377cca6a4
+  fn: billiard-{{ version }}.tar.gz
+  url: https://pypi.python.org/packages/source/b/billiard/billiard-{{ version }}.tar.gz
+  md5: 6ee416e1e7c8d8164ce29d7377cca6a4
 
 build:
-    number: 1
-    script: python setup.py install --single-version-externally-managed --record=record.txt
+  number: 1
+  script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:
-    build:
-        - python
-        - setuptools
-    run:
-        - python
+  build:
+    - python
+    - setuptools
+  run:
+    - python
 
 test:
-    imports:
-        - billiard
-        - billiard.dummy
-        - billiard.tests
-        - funtests
+  imports:
+    - billiard
+    - billiard.dummy
+    - billiard.tests
+    - funtests
 
 about:
-    home: http://github.com/celery/billiard
-    license: BSD License
-    summary: Python multiprocessing fork with improvements and bugfixes
+  home: http://github.com/celery/billiard
+  license: BSD License
+  summary: Python multiprocessing fork with improvements and bugfixes
 
 extra:
-    recipe-maintainers:
-        - jakirkham
-        - kwilcox
+  recipe-maintainers:
+    - jakirkham
+    - kwilcox

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 692a2a5a55ee39a42bcb7557930e2541da85df9ea81c6e24827f63b80cd39d0b
 
 build:
-  number: 1
+  number: 2
   script: python setup.py install --single-version-externally-managed --record=record.txt
 
 requirements:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: billiard-{{ version }}.tar.gz
-  url: https://pypi.python.org/packages/source/b/billiard/billiard-{{ version }}.tar.gz
-  md5: 6ee416e1e7c8d8164ce29d7377cca6a4
+  url: https://pypi.io/packages/source/b/billiard/billiard-{{ version }}.tar.gz
+  sha256: 692a2a5a55ee39a42bcb7557930e2541da85df9ea81c6e24827f63b80cd39d0b
 
 build:
   number: 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,7 +29,9 @@ test:
 
 about:
   home: http://github.com/celery/billiard
-  license: BSD License
+  license: BSD 3-Clause
+  license_family: BSD
+  license_file: LICENSE.txt
   summary: Python multiprocessing fork with improvements and bugfixes
 
 extra:


### PR DESCRIPTION
* Drop `bld.bat` (no longer needed as `script` is supported on Windows).
* Use 2 space indentation in `meta.yaml`.
* Switch to [pypi.io]( https://pypi.io/ ) for downloads.
* Use sha256 checksums for downloads.
* Include license.
* Specify license version
* Add license family.
* Re-render for metadata update.
* Bump build number to get license file in packages.