### PR TITLE
Re-add import tests

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -27,6 +27,8 @@ test:
   imports:
     - billiard
     - billiard.dummy
+    - billiard.tests
+    - funtests
 
 about:
   home: https://github.com/celery/billiard


### PR DESCRIPTION
These were accidentally dropped as they are dropped in the 3.5.x version. However they are still present in the 3.3.x version. So go ahead and re-add them.

xref: https://github.com/conda-forge/billiard-feedstock/pull/11

cc @pmlandwehr